### PR TITLE
Gitspiegel integration tests pt.3

### DIFF
--- a/src/fixtures/github/pullRequest.ts
+++ b/src/fixtures/github/pullRequest.ts
@@ -18,6 +18,8 @@ export type PullRequestParams = {
   repo: string;
   headBranch: string;
   number?: number;
+  repoNodeId?: string;
+  headCommit: string;
 };
 
 export function getPullRequestsPayload(params: PullRequestParams[]): PullRequest[] {
@@ -55,20 +57,28 @@ export function getPullRequestPayload(params: PullRequestParams): PullRequest {
     review_comments_url: `https://api.github.com/repos/${params.org}/${params.repo}/pulls/4/comments`,
     review_comment_url: `https://api.github.com/repos/${params.org}/${params.repo}/pulls/comments{/number}`,
     comments_url: `https://api.github.com/repos/${params.org}/${params.repo}/issues/4/comments`,
-    statuses_url: `https://api.github.com/repos/${params.org}/${params.repo}/statuses/0c84e6dd0ccd531206c8137a2e2e9edaa9907e5d`,
+    statuses_url: `https://api.github.com/repos/${params.org}/${params.repo}/statuses/${params.headCommit}`,
     head: {
       label: `${params.org}:${params.headBranch}`,
       ref: params.headBranch,
-      sha: "0c84e6dd0ccd531206c8137a2e2e9edaa9907e5d",
+      sha: params.headCommit,
       user: getUserPayload({ id: 588262, login: params.login }),
-      repo: getRepoPayload({ name: params.repo, owner: params.org }) as PullRequest["head"]["repo"],
+      repo: getRepoPayload({
+        name: params.repo,
+        owner: params.org,
+        node_id: params.repoNodeId,
+      }) as PullRequest["head"]["repo"],
     },
     base: {
       label: `${params.org}:master`,
       ref: "master",
       sha: "d788763294b8094c66620294725edfc3f653a4ff",
       user: getUserPayload({ id: 74720417, login: params.org }),
-      repo: getRepoPayload({ name: params.repo, owner: params.org }) as PullRequest["base"]["repo"],
+      repo: getRepoPayload({
+        name: params.repo,
+        owner: params.org,
+        node_id: params.repoNodeId,
+      }) as PullRequest["base"]["repo"],
     },
     _links: {
       self: { href: `https://api.github.com/repos/${params.org}/${params.repo}/pulls/4` },
@@ -78,9 +88,7 @@ export function getPullRequestPayload(params: PullRequestParams): PullRequest {
       review_comments: { href: `https://api.github.com/repos/${params.org}/${params.repo}/pulls/4/comments` },
       review_comment: { href: `https://api.github.com/repos/${params.org}/${params.repo}/pulls/comments{/number}` },
       commits: { href: `https://api.github.com/repos/${params.org}/${params.repo}/pulls/4/commits` },
-      statuses: {
-        href: `https://api.github.com/repos/${params.org}/${params.repo}/statuses/0c84e6dd0ccd531206c8137a2e2e9edaa9907e5d`,
-      },
+      statuses: { href: `https://api.github.com/repos/${params.org}/${params.repo}/statuses/${params.headCommit}` },
     },
     author_association: "MEMBER",
     auto_merge: null,

--- a/src/githubWebhooks.ts
+++ b/src/githubWebhooks.ts
@@ -6,6 +6,7 @@ export type TriggerWebhookParams = {
   payload: WebhookEvent;
   githubEventHeader: string;
   port: number;
+  eventId?: string;
 };
 
 export async function triggerWebhook(params: TriggerWebhookParams): Promise<void> {
@@ -20,7 +21,7 @@ export async function triggerWebhook(params: TriggerWebhookParams): Promise<void
       "X-Hub-Signature": `sha1=${signature1}`,
       "X-Hub-Signature-256": `sha256=${signature256}`,
       "X-GitHub-Event": params.githubEventHeader,
-      "X-GitHub-Delivery": "72d3162e-cc78-11e3-81ab-4c9367dc0958",
+      "X-GitHub-Delivery": params.eventId ?? "72d3162e-cc78-11e3-81ab-4c9367dc0958",
     },
   });
 }


### PR DESCRIPTION
1. Cleaning root folder of git daemons. Leftovers from old repos might
lead to false-positives.
2. Proper checkout of tags. Old setup was leading to tags being always
synced because the commits they were pointing to what they were in master.
3. Fixed copying of branches in `copyRepo()`. This is not used yet, but
was broken nevertheless.
4. Added `eventId` support for `triggerWebhook()`. This allows
distinguishing between output in logs. Also, enabler for task management
testing.
5. `repoNodeId` and `headCommit` support for `getPullRequestsPayload()`.
Tests were working incorrectly, this allows for a proper fix.
