### PR TITLE
Properly categorize `formatted_body` in a matrix message as optional

### DIFF
--- a/src/matrixHelpers.ts
+++ b/src/matrixHelpers.ts
@@ -103,7 +103,7 @@ type LatestMessageResponse = {
   chunk: [
     {
       sender: string;
-      content: { body: string; formatted_body: string };
+      content: { body: string; formatted_body: string | undefined };
     },
   ];
 };
@@ -119,7 +119,7 @@ export async function getLatestMessages(
   {
     sender: string;
     body: string;
-    formattedBody: string;
+    formattedBody: string | undefined;
   }[]
 > {
   const res = await validatedFetch<LatestMessageResponse>(
@@ -130,8 +130,7 @@ export async function getLatestMessages(
       chunk: Joi.array().items(
         Joi.object({
           sender: Joi.string().required(),
-          content: Joi.object({ body: Joi.string().required() }),
-          formatted_body: Joi.object({ formatted_body: Joi.string().required() }),
+          content: Joi.object({ body: Joi.string().required(), formatted_body: Joi.string() }),
         }).required(),
       ),
     }),
@@ -152,7 +151,7 @@ export async function getLatestMessage(
 ): Promise<{
   sender: string;
   body: string;
-  formattedBody: string;
+  formattedBody: string | undefined;
 }> {
   return (await getLatestMessages(matrixUrl, params))[0];
 }


### PR DESCRIPTION
The `formatted_body` is actually optional, a message without it can exist.
It was also in the wrong place in Joi validation scheme.