### PR TITLE
Allowing custom token for getAppInstallationTokenPayload

### DIFF
--- a/src/fixtures/github/appInstallationToken.ts
+++ b/src/fixtures/github/appInstallationToken.ts
@@ -3,10 +3,10 @@ import { RestEndpointMethodTypes } from "@octokit/rest";
 export type AppInstallationToken = RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["response"]["data"];
 
 // FIXME: correct type for the payload
-export function getAppInstallationTokenPayload(): AppInstallationToken {
+export function getAppInstallationTokenPayload(token?: string): AppInstallationToken {
   return {
     // This is an example token from docs.github.com
-    token: "ghs_16C7e42F292c6912E7710c838347Ae178B4a",
+    token: token ?? "ghs_16C7e42F292c6912E7710c838347Ae178B4a",
     expires_at: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
     permissions: { issues: "write", contents: "read" },
   };


### PR DESCRIPTION
This'll allow to discern requests for multiple installations setup
